### PR TITLE
Fixed selection box bounds error and double introduction

### DIFF
--- a/src/languageModel/chatBox.ts
+++ b/src/languageModel/chatBox.ts
@@ -272,8 +272,8 @@ export async function sendSystemMessage(message: string): Promise<string> {
     const replyText = Array.isArray(reply.text)
       ? reply.text.join("\n")
       : String(reply.text);
-    const aiMessage = new AIMessage(replyText);
-    historyRef.push(aiMessage);
+    // const aiMessage = new AIMessage(replyText);
+    // historyRef.push(aiMessage); // ! get chat response already pushes
 
     if (
       typeof window !== "undefined" &&

--- a/src/languageModel/tools/placeGridofTiles.ts
+++ b/src/languageModel/tools/placeGridofTiles.ts
@@ -136,7 +136,7 @@ Places a rectangular grid of tiles on the map.
 
 - tileIndex: numeric ID of the tile to place.
 - (xMin, yMin): top-left inclusive coordinates.
-- (xMax, yMax): bottom-right exclusive coordinates.
+- (xMax, yMax): bottom-right inclusive coordinates.
 - layerName: the name of the target map layer. Choose between 'Ground_Layer' and 'Collectables_Layer' 
 `,
     },


### PR DESCRIPTION
Changed the description of grid place tool from "inclusive-exclusive" to "inclusive-inclusive" to allow correct use of placements

Removed a double push of the introduction message